### PR TITLE
Fix error without system option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
-            <version>10.0.2</version>
+            <version>11.0.3</version>
 <!--            <exclusions>-->
 <!--                <exclusion>-->
 <!--                    <groupId>org.slf4j</groupId>-->

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
@@ -22,12 +22,14 @@ import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.info.ServerInfoRepresentation;
 
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ext.RuntimeDelegate;
 
 import static jp.openstandia.connector.keycloak.KeycloakUtils.getRootCause;
 
@@ -49,6 +51,13 @@ public class KeycloakAdminRESTClient implements KeycloakClient {
     public KeycloakAdminRESTClient(String instanceName, KeycloakConfiguration configuration) {
         this.instanceName = instanceName;
         this.cofiguration = configuration;
+
+        try {
+            RuntimeDelegate.getInstance();
+        } catch (RuntimeException e) {
+            // Set the implementation directly as a workaround
+            RuntimeDelegate.setInstance(new ResteasyProviderFactory());
+        }
 
         ResteasyClientBuilder resteasyClientBuilder = new ResteasyClientBuilder();
         resteasyClientBuilder.connectionPoolSize(20);


### PR DESCRIPTION
Currently, the connector needs system option `-Djavax.ws.rs.ext.RuntimeDelegate=org.jboss.resteasy.spi.ResteasyProviderFactory` (or need `jersey-common-*.jar`) for midPoint since midPoint uses `org.identityconnectors.framework.impl.api.local.BundleClassLoader` which can't load the class through `ServiceLoader`.

This pull request adds the fallback when it can't find the implementation class.