### PR TITLE
fix: Make name of client and clientRole objects case-insensitive

### DIFF
--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakClientHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakClientHandler.java
@@ -89,6 +89,7 @@ public class KeycloakClientHandler extends AbstractKeycloakHandler {
                 .setRequired(true)
                 .setUpdateable(true)
                 .setNativeName(ATTR_CLIENT_ID)
+                .setSubtype(AttributeInfo.Subtypes.STRING_CASE_IGNORE)
                 .build());
 
         // Common Attributes

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakClientRoleHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakClientRoleHandler.java
@@ -69,6 +69,7 @@ public class KeycloakClientRoleHandler extends AbstractKeycloakHandler {
                 .setRequired(true)
                 .setUpdateable(true)
                 .setNativeName(ATTR_NAME)
+                .setSubtype(AttributeInfo.Subtypes.STRING_CASE_IGNORE)
                 .build());
 
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_DESCRIPTION)


### PR DESCRIPTION
From keycloak 12, the name is case-insensitive.