### PR TITLE
Client role associations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakGroupHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakGroupHandler.java
@@ -46,6 +46,7 @@ public class KeycloakGroupHandler extends AbstractKeycloakHandler {
 
     // Association
     public static final String ATTR_PARENT_GROUP = "parentGroup";
+    public static final String ATTR_CLIENT_ROLES = "clientRoles";
     public static final String ATTR_SUB_GROUPS = "subGroups";
 
     public KeycloakGroupHandler(String instanceName, KeycloakConfiguration configuration, KeycloakClient client,
@@ -105,6 +106,11 @@ public class KeycloakGroupHandler extends AbstractKeycloakHandler {
         // Association
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_PARENT_GROUP)
                 .setMultiValued(false)
+                .setReturnedByDefault(false)
+                .build());
+
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_CLIENT_ROLES)
+                .setMultiValued(true)
                 .setReturnedByDefault(false)
                 .build());
 

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
@@ -56,6 +56,7 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
     // Association
     // groups is a list of keycloak group's id
     public static final String ATTR_GROUPS = "groups";
+    public static final String ATTR_CLIENT_ROLES = "clientRoles";
 
     // Password
     public static final String ATTR_PASSWORD = "__PASSWORD__";
@@ -183,6 +184,11 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
 
         // Association
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_GROUPS)
+                .setMultiValued(true)
+                .setReturnedByDefault(false)
+                .build());
+
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_CLIENT_ROLES)
                 .setMultiValued(true)
                 .setReturnedByDefault(false)
                 .build());

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTAdminClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTAdminClient.java
@@ -16,6 +16,8 @@
 package jp.openstandia.connector.keycloak.rest;
 
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import jp.openstandia.connector.keycloak.KeycloakClient;
 import jp.openstandia.connector.keycloak.KeycloakConfiguration;
 import org.identityconnectors.common.StringUtil;
@@ -28,9 +30,6 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.info.ServerInfoRepresentation;
-
-import jakarta.ws.rs.ProcessingException;
-import jakarta.ws.rs.ext.RuntimeDelegate;
 
 import static jp.openstandia.connector.keycloak.KeycloakUtils.getRootCause;
 

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
@@ -15,6 +15,8 @@
  */
 package jp.openstandia.connector.keycloak.rest;
 
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import jp.openstandia.connector.keycloak.KeycloakClient;
 import jp.openstandia.connector.keycloak.KeycloakConfiguration;
 import jp.openstandia.connector.keycloak.KeycloakSchema;
@@ -30,8 +32,6 @@ import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClient.java
@@ -427,7 +427,10 @@ public class KeycloakAdminRESTClient implements KeycloakClient.Client {
 
         // openid-connect
         if (shouldReturn(attributesToGet, ATTR_SECRET)) {
-            builder.addAttribute(ATTR_SECRET, rep.getSecret());
+            if (rep.getSecret() != null) {
+                GuardedString secret = new GuardedString(rep.getSecret().toCharArray());
+                builder.addAttribute(ATTR_SECRET, secret);
+            }
         }
         if (shouldReturn(attributesToGet, ATTR_PUBLIC_CLIENT)) {
             builder.addAttribute(ATTR_PUBLIC_CLIENT, rep.isPublicClient());

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClientRole.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTClientRole.java
@@ -15,6 +15,7 @@
  */
 package jp.openstandia.connector.keycloak.rest;
 
+import jakarta.ws.rs.NotFoundException;
 import jp.openstandia.connector.keycloak.KeycloakClient;
 import jp.openstandia.connector.keycloak.KeycloakConfiguration;
 import jp.openstandia.connector.keycloak.KeycloakSchema;
@@ -31,7 +32,6 @@ import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-import jakarta.ws.rs.NotFoundException;
 import java.util.*;
 
 import static jp.openstandia.connector.keycloak.KeycloakClientHandler.ATTR_CLIENT_UUID;

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTGroup.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTGroup.java
@@ -175,11 +175,14 @@ public class KeycloakAdminRESTGroup implements KeycloakClient.Group {
                     } if (delta.getValuesToRemove() != null){
                         for (Object role : delta.getValuesToRemove()) {
                             String[] parts = role.toString().split("/", 2);
-                            group.roles().clientLevel(parts[0]).remove(List.of(
+                            RoleRepresentation removedRole =
                                     realm(realmName)
+                                            .clients()
+                                            .get(parts[0])
                                             .roles()
                                             .get(parts[1])
-                                            .toRepresentation()));
+                                            .toRepresentation();
+                            group.roles().clientLevel(parts[0]).remove(List.of(removedRole));
                         }
                     }
                 } else if (schema.isGroupSchema(delta)) {

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTGroup.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTGroup.java
@@ -15,6 +15,8 @@
  */
 package jp.openstandia.connector.keycloak.rest;
 
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import jp.openstandia.connector.keycloak.KeycloakClient;
 import jp.openstandia.connector.keycloak.KeycloakConfiguration;
 import jp.openstandia.connector.keycloak.KeycloakSchema;
@@ -27,14 +29,15 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.GroupResource;
 import org.keycloak.admin.client.resource.GroupsResource;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static jp.openstandia.connector.keycloak.KeycloakGroupHandler.*;
+import static jp.openstandia.connector.keycloak.KeycloakUserHandler.ATTR_CLIENT_ROLES;
 import static jp.openstandia.connector.keycloak.KeycloakUtils.*;
 import static jp.openstandia.connector.keycloak.rest.KeycloakRESTUtils.checkCreateResult;
 
@@ -84,7 +87,23 @@ public class KeycloakAdminRESTGroup implements KeycloakClient.Group {
         }
 
         String uuid = checkCreateResult(res, "createGroup");
-
+        Optional<Attribute> clientRolesAttr = createAttributes.stream()
+                .filter(a -> a.getName().equals(ATTR_CLIENT_ROLES))
+                .findFirst();
+        if (clientRolesAttr.isPresent()){
+            List<String> clientRoles = clientRolesAttr.get().getValue().stream().map(Object::toString).toList();
+            for (String clientRole : clientRoles){
+                String[] parts = clientRole.split("/", 2);
+                //find the role representation of the role we want to add
+                RoleRepresentation roleToAdd = realm(realmName)
+                        .clients()
+                        .get(parts[0])
+                        .roles()
+                        .get(parts[1])
+                        .toRepresentation();
+                groups(realmName).group(uuid).roles().clientLevel(parts[0]).add(List.of(roleToAdd));
+            }
+        }
         return new Uid(uuid, new Name(rep.getName()));
     }
 
@@ -126,7 +145,6 @@ public class KeycloakAdminRESTGroup implements KeycloakClient.Group {
         GroupsResource resource = groups(realmName);
         GroupRepresentation current;
         String newParentGroupId = null;
-
         try {
             GroupResource group = resource.group(uid.getUidValue());
             current = group.toRepresentation();
@@ -142,6 +160,28 @@ public class KeycloakAdminRESTGroup implements KeycloakClient.Group {
                 } else if (delta.getName().equals(ATTR_PARENT_GROUP)) {
                     newParentGroupId = AttributeDeltaUtil.getAsStringValue(delta);
 
+                } else if (delta.getName().equals(ATTR_CLIENT_ROLES)) {
+                    if (delta.getValuesToAdd() != null){
+                        for (Object role : delta.getValuesToAdd()) {
+                            String[] parts = role.toString().split("/", 2);
+                            RoleRepresentation roleToAdd = realm(realmName)
+                                    .clients()
+                                    .get(parts[0])
+                                    .roles()
+                                    .get(parts[1])
+                                    .toRepresentation();
+                            group.roles().clientLevel(parts[0]).add(List.of(roleToAdd));
+                        }
+                    } if (delta.getValuesToRemove() != null){
+                        for (Object role : delta.getValuesToRemove()) {
+                            String[] parts = role.toString().split("/", 2);
+                            group.roles().clientLevel(parts[0]).remove(List.of(
+                                    realm(realmName)
+                                            .roles()
+                                            .get(parts[1])
+                                            .toRepresentation()));
+                        }
+                    }
                 } else if (schema.isGroupSchema(delta)) {
                     if (schema.isMultiValuedGroupSchema(delta)) {
                         Map<String, List<String>> attrs = current.getAttributes();
@@ -328,7 +368,24 @@ public class KeycloakAdminRESTGroup implements KeycloakClient.Group {
                 .setName(rep.getName());
 
         builder.addAttribute(ATTR_PATH, rep.getPath());
-
+        if (shouldReturn(attributesToGet,ATTR_CLIENT_ROLES)){
+            List<RoleRepresentation> clientRolesList = new ArrayList<>();
+            for (ClientRepresentation client : realm(realmName).clients().findAll()) {
+                clientRolesList.addAll(
+                        //find all clientRoles from a user for specified client
+                        realm(realmName)
+                                .groups()
+                                .group(rep.getId())
+                                .roles()
+                                .clientLevel(client.getId())
+                                .listAll());
+            }
+            List<String> clientRolesStrings = clientRolesList
+                    .stream()
+                    .map(a -> a.getContainerId() + "/" + a.getName())
+                    .toList();
+            builder.addAttribute(ATTR_CLIENT_ROLES, clientRolesStrings);
+        }
         Map<String, List<String>> attributes = rep.getAttributes();
         if (attributes != null) {
             for (Map.Entry<String, List<String>> entry : rep.getAttributes().entrySet()) {

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
@@ -15,6 +15,9 @@
  */
 package jp.openstandia.connector.keycloak.rest;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import jp.openstandia.connector.keycloak.KeycloakClient;
 import jp.openstandia.connector.keycloak.KeycloakConfiguration;
 import jp.openstandia.connector.keycloak.KeycloakSchema;
@@ -29,13 +32,8 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.representations.idm.CredentialRepresentation;
-import org.keycloak.representations.idm.GroupRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.*;
 
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -116,7 +114,23 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                 }
             }
         }
-
+        Optional<Attribute> clientRolesAttr = createAttributes.stream()
+                .filter(a -> a.getName().equals(ATTR_CLIENT_ROLES))
+                .findFirst();
+        if (clientRolesAttr.isPresent()){
+            List<String> clientRoles = clientRolesAttr.get().getValue().stream().map(Object::toString).toList();
+                for (String clientRole : clientRoles){
+                    String[] parts = clientRole.split("/", 2);
+                    //find the role representation of the role we want to add
+                    RoleRepresentation roleToAdd = realm(realmName)
+                            .clients()
+                            .get(parts[0])
+                            .roles()
+                            .get(parts[1])
+                            .toRepresentation();
+                    users(realmName).get(uuid).roles().clientLevel(parts[0]).add(List.of(roleToAdd));
+                }
+        }
         return new Uid(uuid, new Name(newUser.getUsername()));
     }
 
@@ -162,26 +176,38 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                 // See createUser method.
                 List<String> groups = attr.getValue().stream().map(a -> a.toString()).collect(Collectors.toList());
                 newUser.setGroups(groups);
+            } else if (!schema.isUserSchema(attr)) {
+                throw new InvalidAttributeValueException(String.format("Keycloak doesn't support to set '%s' attribute of User",
+                        attr.getName()));
+            }
+            if (schema.isMultiValuedUserSchema(attr)) {
+                Map<String, List<String>> attrs = newUser.getAttributes();
+                if (attrs == null) {
+                    attrs = new HashMap();
+                }
+                attrs.put(attr.getName(), attr.getValue().stream().map(a -> a.toString()).collect(Collectors.toList()));
 
             } else {
-                if (!schema.isUserSchema(attr)) {
-                    throw new InvalidAttributeValueException(String.format("Keycloak doesn't support to set '%s' attribute of User",
-                            attr.getName()));
-                }
-                if (schema.isMultiValuedUserSchema(attr)) {
-                    Map<String, List<String>> attrs = newUser.getAttributes();
-                    if (attrs == null) {
-                        attrs = new HashMap();
-                    }
-                    attrs.put(attr.getName(), attr.getValue().stream().map(a -> a.toString()).collect(Collectors.toList()));
+                newUser.singleAttribute(attr.getName(), AttributeUtil.getStringValue(attr));
+            }
 
-                } else {
-                    newUser.singleAttribute(attr.getName(), AttributeUtil.getStringValue(attr));
-                }
+        }
+        return newUser;
+    }
+
+    private Map<String, List<String>> groupClientRolesByClient(List<String> clientRolesList) {
+        Map<String, List<String>> result = new HashMap<>();
+
+        for (String role : clientRolesList) {
+            String[] parts = role.split("/", 2); // Split into key and value
+            if (parts.length == 2) {
+                String key = parts[0];
+                String value = parts[1];
+                // Add value to the list for the key
+                result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
             }
         }
-
-        return newUser;
+        return result;
     }
 
     private void updatePassword(String realmName, String userId, CredentialRepresentation credential, final Boolean permanent)
@@ -261,7 +287,30 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                             removeGroupIds.add(group.toString());
                         }
                     }
-
+                } else if (delta.getName().equals(ATTR_CLIENT_ROLES)) {
+                    if (delta.getValuesToAdd() != null) {
+                        for (Object role : delta.getValuesToAdd()) {
+                            String[] parts = role.toString().split("/", 2);
+                            RoleRepresentation roleToAdd = realm(realmName)
+                                    .clients()
+                                    .get(parts[0])
+                                    .roles()
+                                    .get(parts[1])
+                                    .toRepresentation();
+                            String clientId = roleToAdd.getContainerId();
+                            user.roles().clientLevel(parts[0]).add(List.of(roleToAdd));
+                        }
+                    }
+                    if (delta.getValuesToRemove() != null) {
+                        for (Object role : delta.getValuesToRemove()) {
+                            String[] parts = role.toString().split("/", 2);
+                            user.roles().clientLevel(parts[0]).remove(List.of(
+                                    realm(realmName)
+                                            .roles()
+                                            .get(parts[1])
+                                            .toRepresentation()));
+                        }
+                    }
                 } else if (schema.isUserSchema(delta)) {
                     if (schema.isMultiValuedUserSchema(delta)) {
                         Map<String, List<String>> attrs = current.getAttributes();
@@ -320,7 +369,6 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         // Although this connector doesn't handle this situation, IDM can retry the update to resolve this inconsistency.
 
         updatePassword(realmName, current.getId(), credential, true);
-
         for (String groupId : addGroupIds) {
             try {
                 users(realmName).get(current.getId()).joinGroup(groupId);
@@ -464,6 +512,24 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         }
         if (shouldReturn(attributesToGet, ATTR_LAST_NAME)) {
             builder.addAttribute(ATTR_LAST_NAME, user.getLastName());
+        }
+        if (shouldReturn(attributesToGet, ATTR_CLIENT_ROLES)) {
+            List<RoleRepresentation> clientRolesList = new ArrayList<>();
+            for (ClientRepresentation client : realm(realmName).clients().findAll()) {
+                clientRolesList.addAll(
+                        //find all clientRoles from a user for specified client
+                        realm(realmName)
+                                .users()
+                                .get(user.getId())
+                                .roles()
+                                .clientLevel(client.getId())
+                                .listAll());
+            }
+            List<String> clientRolesStrings = clientRolesList
+                    .stream()
+                    .map(a -> a.getContainerId() + "/" + a.getName())
+                    .toList();
+            builder.addAttribute(ATTR_CLIENT_ROLES, clientRolesStrings);
         }
 
         Map<String, List<String>> attributes = user.getAttributes();

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
@@ -117,19 +117,19 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         Optional<Attribute> clientRolesAttr = createAttributes.stream()
                 .filter(a -> a.getName().equals(ATTR_CLIENT_ROLES))
                 .findFirst();
-        if (clientRolesAttr.isPresent()){
+        if (clientRolesAttr.isPresent()) {
             List<String> clientRoles = clientRolesAttr.get().getValue().stream().map(Object::toString).toList();
-                for (String clientRole : clientRoles){
-                    String[] parts = clientRole.split("/", 2);
-                    //find the role representation of the role we want to add
-                    RoleRepresentation roleToAdd = realm(realmName)
-                            .clients()
-                            .get(parts[0])
-                            .roles()
-                            .get(parts[1])
-                            .toRepresentation();
-                    users(realmName).get(uuid).roles().clientLevel(parts[0]).add(List.of(roleToAdd));
-                }
+            for (String clientRole : clientRoles) {
+                String[] parts = clientRole.split("/", 2);
+                //find the role representation of the role we want to add
+                RoleRepresentation roleToAdd = realm(realmName)
+                        .clients()
+                        .get(parts[0])
+                        .roles()
+                        .get(parts[1])
+                        .toRepresentation();
+                users(realmName).get(uuid).roles().clientLevel(parts[0]).add(List.of(roleToAdd));
+            }
         }
         return new Uid(uuid, new Name(newUser.getUsername()));
     }
@@ -193,6 +193,21 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
 
         }
         return newUser;
+    }
+
+    private Map<String, List<String>> groupClientRolesByClient(List<String> clientRolesList) {
+        Map<String, List<String>> result = new HashMap<>();
+
+        for (String role : clientRolesList) {
+            String[] parts = role.split("/", 2); // Split into key and value
+            if (parts.length == 2) {
+                String key = parts[0];
+                String value = parts[1];
+                // Add value to the list for the key
+                result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+            }
+        }
+        return result;
     }
 
     private void updatePassword(String realmName, String userId, CredentialRepresentation credential, final Boolean permanent)
@@ -274,6 +289,7 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                     }
                 } else if (delta.getName().equals(ATTR_CLIENT_ROLES)) {
                     if (delta.getValuesToAdd() != null) {
+                        //Roles are added one by one as lists of 1 item because they are each added under their respective clients
                         for (Object role : delta.getValuesToAdd()) {
                             String[] parts = role.toString().split("/", 2);
                             RoleRepresentation roleToAdd = realm(realmName)
@@ -282,18 +298,20 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                                     .roles()
                                     .get(parts[1])
                                     .toRepresentation();
-                            String clientId = roleToAdd.getContainerId();
                             user.roles().clientLevel(parts[0]).add(List.of(roleToAdd));
                         }
                     }
                     if (delta.getValuesToRemove() != null) {
                         for (Object role : delta.getValuesToRemove()) {
                             String[] parts = role.toString().split("/", 2);
-                            user.roles().clientLevel(parts[0]).remove(List.of(
+                            RoleRepresentation removedRole =
                                     realm(realmName)
+                                            .clients()
+                                            .get(parts[0])
                                             .roles()
                                             .get(parts[1])
-                                            .toRepresentation()));
+                                            .toRepresentation();
+                            user.roles().clientLevel(parts[0]).remove(List.of(removedRole));
                         }
                     }
                 } else if (schema.isUserSchema(delta)) {

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
@@ -195,21 +195,6 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         return newUser;
     }
 
-    private Map<String, List<String>> groupClientRolesByClient(List<String> clientRolesList) {
-        Map<String, List<String>> result = new HashMap<>();
-
-        for (String role : clientRolesList) {
-            String[] parts = role.split("/", 2); // Split into key and value
-            if (parts.length == 2) {
-                String key = parts[0];
-                String value = parts[1];
-                // Add value to the list for the key
-                result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
-            }
-        }
-        return result;
-    }
-
     private void updatePassword(String realmName, String userId, CredentialRepresentation credential, final Boolean permanent)
             throws InvalidAttributeValueException {
         if (credential == null) {

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakRESTUtils.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakRESTUtils.java
@@ -15,11 +15,10 @@
  */
 package jp.openstandia.connector.keycloak.rest;
 
-import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
-import org.identityconnectors.framework.common.exceptions.ConnectorException;
-
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
 
 /**
  * Utilities for Keycloak Admin REST client.


### PR DESCRIPTION
I have made some changes to allow for associations to be made between clientRoles and Groups/Users.
Changes:
 - Added clientRoles to user and group schema
 - Added clientRole assignment & unassignment for users and groups
 - Changed secret to be returned as GuardedString in get for clients 
Developed and tested in midPoint 4.9/4.10
This is a simulated reference type definition to work with the association clientRole <-> User
```XML
            <cap:references>
                <cap:type>
                    <cap:name>clientRoleReferenceUser</cap:name>
                    <cap:subject>
                        <cap:delineation>
                            <cap:objectClass>ri:user</cap:objectClass>
                        </cap:delineation>
                        <cap:primaryBindingAttributeRef>clientRoles</cap:primaryBindingAttributeRef>
                        <cap:localItemName>clientRoleAssignments</cap:localItemName>
                    </cap:subject>
                    <cap:object>
                        <cap:delineation>
                            <cap:objectClass>ri:clientRole</cap:objectClass>
                        </cap:delineation>
                        <cap:primaryBindingAttributeRef>name</cap:primaryBindingAttributeRef>
                    </cap:object>
                    <cap:direction>subjectToObject</cap:direction>
                </cap:type>
           </cap:references>

