### PR TITLE
Add Realm Role support using Google Antigravity

### DIFF
--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakClient.java
@@ -39,6 +39,8 @@ public interface KeycloakClient {
 
     ClientRole clientRole();
 
+    RealmRole realmRole();
+
     interface User {
         Uid createUser(KeycloakSchema schema, String realmName, Set<Attribute> createAttributes) throws AlreadyExistsException;
 
@@ -93,6 +95,20 @@ public interface KeycloakClient {
         void getClientRole(KeycloakSchema schema, String realmName, Uid uid, ResultsHandler handler, OperationOptions options, Set<String> attributesToGet, int queryPageSize);
 
         void getClientRole(KeycloakSchema schema, String realmName, Name name, ResultsHandler handler, OperationOptions options, Set<String> attributesToGet, int queryPageSize);
+    }
+
+    interface RealmRole {
+        Uid createRealmRole(KeycloakSchema schema, String realmName, Set<Attribute> createAttributes) throws AlreadyExistsException;
+
+        void updateRealmRole(KeycloakSchema schema, String realmName, Uid uid, Set<AttributeDelta> modifications, OperationOptions options) throws UnknownUidException;
+
+        void deleteRealmRole(KeycloakSchema schema, String realmName, Uid uid, OperationOptions options) throws UnknownUidException;
+
+        void getRealmRoles(KeycloakSchema schema, String realmName, ResultsHandler handler, OperationOptions options, Set<String> attributesToGet, int queryPageSize);
+
+        void getRealmRole(KeycloakSchema schema, String realmName, Uid uid, ResultsHandler handler, OperationOptions options, Set<String> attributesToGet, int queryPageSize);
+
+        void getRealmRole(KeycloakSchema schema, String realmName, Name name, ResultsHandler handler, OperationOptions options, Set<String> attributesToGet, int queryPageSize);
     }
 
     void close();

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakConfiguration.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakConfiguration.java
@@ -38,6 +38,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     private String userAttributes;
     private String groupAttributes;
     private String clientAttributes;
+    private String realmRoleAttributes;
     private int queryPageSize;
     private boolean passwordResetAPIEnabled;
     private boolean grpcEnabled;
@@ -194,6 +195,20 @@ public class KeycloakConfiguration extends AbstractConfiguration {
 
     @ConfigurationProperty(
             order = 11,
+            displayMessageKey = "Realm Role Attributes",
+            helpMessageKey = "Keycloak realm role attributes (comma-separated).",
+            required = false,
+            confidential = false)
+    public String getRealmRoleAttributes() {
+        return realmRoleAttributes;
+    }
+
+    public void setRealmRoleAttributes(String realmRoleAttributes) {
+        this.realmRoleAttributes = realmRoleAttributes;
+    }
+
+    @ConfigurationProperty(
+            order = 12,
             displayMessageKey = "Query Page Size",
             helpMessageKey = "Page size of search query in the connector. Default is 100.",
             required = false,
@@ -210,7 +225,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 12,
+            order = 13,
             displayMessageKey = "Enable Password Reset API for update password",
             helpMessageKey = "If yes, the connector uses password reset API instead of create/update user API. " +
                     "Pros. The raw password isn't recorded in the Keycloak admin event. " +
@@ -226,7 +241,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 13,
+            order = 14,
             displayMessageKey = "Enable gRPC",
             helpMessageKey = "Enable gRPC for the Keycloak API. CAUTION: You need to install keycloak-grpc on the Keycloak server.",
             required = false,
@@ -240,7 +255,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 14,
+            order = 15,
             displayMessageKey = "gRPC Host",
             helpMessageKey = "Hostname for gRPC connection.",
             required = false,
@@ -254,7 +269,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 15,
+            order = 16,
             displayMessageKey = "gRPC Port",
             helpMessageKey = "Port for gRPC connection.",
             required = false,
@@ -268,7 +283,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 16,
+            order = 17,
             displayMessageKey = "HTTP Proxy Host",
             helpMessageKey = "Hostname for the HTTP Proxy",
             required = false,
@@ -282,7 +297,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 17,
+            order = 18,
             displayMessageKey = "HTTP Proxy Port",
             helpMessageKey = "Port for the HTTP Proxy",
             required = false,
@@ -296,7 +311,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 18,
+            order = 19,
             displayMessageKey = "HTTP Proxy User",
             helpMessageKey = "Username for the HTTP Proxy Authentication",
             required = false,
@@ -310,7 +325,7 @@ public class KeycloakConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(
-            order = 19,
+            order = 20,
             displayMessageKey = "HTTP Proxy Password",
             helpMessageKey = "Password for the HTTP Proxy Authentication",
             required = false,

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakConnector.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakConnector.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import static jp.openstandia.connector.keycloak.KeycloakClientHandler.CLIENT_OBJECT_CLASS;
 import static jp.openstandia.connector.keycloak.KeycloakClientRoleHandler.CLIENT_ROLE_OBJECT_CLASS;
 import static jp.openstandia.connector.keycloak.KeycloakGroupHandler.GROUP_OBJECT_CLASS;
+import static jp.openstandia.connector.keycloak.KeycloakRealmRoleHandler.REALM_ROLE_OBJECT_CLASS;
 import static jp.openstandia.connector.keycloak.KeycloakUserHandler.USER_OBJECT_CLASS;
 
 /**
@@ -116,6 +117,9 @@ public class KeycloakConnector implements PoolableConnector, CreateOp, UpdateDel
 
         } else if (objectClass.equals(CLIENT_ROLE_OBJECT_CLASS)) {
             return new KeycloakClientRoleHandler(instanceName, configuration, client, schema);
+
+        } else if (objectClass.equals(REALM_ROLE_OBJECT_CLASS)) {
+            return new KeycloakRealmRoleHandler(instanceName, configuration, client, schema);
 
         } else {
             throw new InvalidAttributeValueException("Unsupported object class " + objectClass);

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakRealmRoleHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakRealmRoleHandler.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright Nomura Research Institute, Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package jp.openstandia.connector.keycloak;
+
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
+import org.identityconnectors.framework.common.objects.*;
+
+import java.util.Set;
+
+import static jp.openstandia.connector.keycloak.KeycloakUtils.createFullAttributesToGet;
+
+/**
+ * Handle keycloak realm role object.
+ *
+ * @author Hiroyuki Wada
+ */
+public class KeycloakRealmRoleHandler extends AbstractKeycloakHandler {
+
+    public static final ObjectClass REALM_ROLE_OBJECT_CLASS = new ObjectClass("realmRole");
+
+    private static final Log LOGGER = Log.getLog(KeycloakRealmRoleHandler.class);
+
+    // Unique and changeable within the keycloak realm.
+    public static final String ATTR_NAME = "name";
+
+    // Unique and unchangeable within the keycloak realm.
+    // Don't use "id" here because it conflicts midpoint side.
+    public static final String ATTR_REALM_ROLE_ID = "realmRoleId";
+
+    public static final String ATTR_DESCRIPTION = "description";
+    public static final String ATTR_ATTRIBUTES = "attributes";
+
+    public KeycloakRealmRoleHandler(String instanceName, KeycloakConfiguration configuration, KeycloakClient client,
+                                     KeycloakSchema schema) {
+        super(instanceName, configuration, client, schema);
+    }
+
+    public static ObjectClassInfo getSchema(String[] attributes) {
+        ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
+        builder.setType(REALM_ROLE_OBJECT_CLASS.getObjectClassValue());
+
+        // __UID__
+        builder.addAttributeInfo(AttributeInfoBuilder.define(Uid.NAME)
+                .setRequired(false) // Must be optional. It is not present for create operations
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setNativeName(ATTR_REALM_ROLE_ID)
+                .build());
+
+        // __NAME__
+        builder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME)
+                .setRequired(true)
+                .setUpdateable(true)
+                .setNativeName(ATTR_NAME)
+                .setSubtype(AttributeInfo.Subtypes.STRING_CASE_IGNORE)
+                .build());
+
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_DESCRIPTION)
+                .setRequired(false)
+                .build());
+
+        // Attributes
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_ATTRIBUTES)
+                .setRequired(false)
+                .setMultiValued(true)
+                .build());
+
+        ObjectClassInfo info = builder.build();
+
+        LOGGER.info("The constructed realmRole core schema: {0}", info);
+
+        return info;
+    }
+
+    /**
+     * @param attributes
+     * @return
+     * @throws AlreadyExistsException Object with the specified _NAME_ already exists.
+     *                                Or there is a similar violation in any of the object attributes that
+     *                                cannot be distinguished from AlreadyExists situation.
+     */
+    @Override
+    public Uid create(Set<Attribute> attributes) throws AlreadyExistsException {
+        return client.realmRole().createRealmRole(schema, configuration.getTargetRealmName(), attributes);
+    }
+
+    /**
+     * @param uid
+     * @param modifications
+     * @param options
+     * @return
+     */
+    @Override
+    public Set<AttributeDelta> updateDelta(Uid uid, Set<AttributeDelta> modifications, OperationOptions options) {
+        client.realmRole().updateRealmRole(schema, configuration.getTargetRealmName(), uid, modifications, options);
+
+        return null;
+    }
+
+    /**
+     * @param uid
+     * @param options
+     */
+    @Override
+    public void delete(Uid uid, OperationOptions options) {
+        client.realmRole().deleteRealmRole(schema, configuration.getTargetRealmName(), uid, options);
+    }
+
+    /**
+     * @param filter
+     * @param resultsHandler
+     * @param options
+     */
+    @Override
+    public void query(KeycloakFilter filter,
+                      ResultsHandler resultsHandler, OperationOptions options) {
+        // Create full attributesToGet by RETURN_DEFAULT_ATTRIBUTES + ATTRIBUTES_TO_GET
+        Set<String> attributesToGet = createFullAttributesToGet(schema.realmRoleSchema, options);
+
+        if (filter == null) {
+            client.realmRole().getRealmRoles(schema, configuration.getTargetRealmName(),
+                    resultsHandler, options, attributesToGet, configuration.getQueryPageSize());
+        } else {
+            if (filter.isByUid()) {
+                client.realmRole().getRealmRole(schema, configuration.getTargetRealmName(), filter.uid,
+                        resultsHandler, options, attributesToGet, configuration.getQueryPageSize());
+            } else {
+                client.realmRole().getRealmRole(schema, configuration.getTargetRealmName(), filter.name,
+                        resultsHandler, options, attributesToGet, configuration.getQueryPageSize());
+            }
+        }
+    }
+}

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakSchema.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakSchema.java
@@ -43,6 +43,7 @@ public class KeycloakSchema {
     public final Map<String, AttributeInfo> groupSchema;
     public final Map<String, AttributeInfo> clientSchema;
     public final Map<String, AttributeInfo> clientRoleSchema;
+    public final Map<String, AttributeInfo> realmRoleSchema;
 
     public KeycloakSchema(KeycloakConfiguration configuration, KeycloakClient client) {
         this.configuration = configuration;
@@ -61,6 +62,9 @@ public class KeycloakSchema {
 
         ObjectClassInfo clientRoleSchemaInfo = KeycloakClientRoleHandler.getSchema(new String[]{});
         schemaBuilder.defineObjectClass(clientRoleSchemaInfo);
+
+        ObjectClassInfo realmRoleSchemaInfo = KeycloakRealmRoleHandler.getSchema(getRealmRoleAttributes());
+        schemaBuilder.defineObjectClass(realmRoleSchemaInfo);
 
         schemaBuilder.defineOperationOption(OperationOptionInfoBuilder.buildAttributesToGet(), SearchOp.class);
         schemaBuilder.defineOperationOption(OperationOptionInfoBuilder.buildReturnDefaultAttributes(), SearchOp.class);
@@ -87,10 +91,16 @@ public class KeycloakSchema {
             clientRoleSchemaMap.put(info.getName(), info);
         }
 
+        Map<String, AttributeInfo> realmRoleSchemaMap = new HashMap<>();
+        for (AttributeInfo info : realmRoleSchemaInfo.getAttributeInfo()) {
+            realmRoleSchemaMap.put(info.getName(), info);
+        }
+
         this.userSchema = Collections.unmodifiableMap(userSchemaMap);
         this.groupSchema = Collections.unmodifiableMap(groupSchemaMap);
         this.clientSchema = Collections.unmodifiableMap(clientSchemaMap);
         this.clientRoleSchema = Collections.unmodifiableMap(clientRoleSchemaMap);
+        this.realmRoleSchema = Collections.unmodifiableMap(realmRoleSchemaMap);
 
         this.version = client.getVersion();
 
@@ -133,6 +143,14 @@ public class KeycloakSchema {
         String clientAttributes = configuration.getClientAttributes();
         if (clientAttributes != null) {
             return clientAttributes.split(",");
+        }
+        return new String[]{};
+    }
+
+    private String[] getRealmRoleAttributes() {
+        String realmRoleAttributes = configuration.getRealmRoleAttributes();
+        if (realmRoleAttributes != null) {
+            return realmRoleAttributes.split(",");
         }
         return new String[]{};
     }
@@ -195,5 +213,25 @@ public class KeycloakSchema {
 
     public AttributeInfo getClientSchema(String attributeName) {
         return clientSchema.get(attributeName);
+    }
+
+    public boolean isRealmRoleSchema(Attribute attribute) {
+        return realmRoleSchema.containsKey(attribute.getName());
+    }
+
+    public boolean isMultiValuedRealmRoleSchema(Attribute attribute) {
+        return realmRoleSchema.get(attribute.getName()).isMultiValued();
+    }
+
+    public boolean isRealmRoleSchema(AttributeDelta delta) {
+        return realmRoleSchema.containsKey(delta.getName());
+    }
+
+    public boolean isMultiValuedRealmRoleSchema(AttributeDelta delta) {
+        return realmRoleSchema.get(delta.getName()).isMultiValued();
+    }
+
+    public AttributeInfo getRealmRoleSchema(String attributeName) {
+        return realmRoleSchema.get(attributeName);
     }
 }

--- a/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/KeycloakUserHandler.java
@@ -57,6 +57,9 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
     // groups is a list of keycloak group's id
     public static final String ATTR_GROUPS = "groups";
 
+    // roles is a list of keycloak realm role names
+    public static final String ATTR_ROLES = "roles";
+
     // Password
     public static final String ATTR_PASSWORD = "__PASSWORD__";
     public static final String ATTR_PASSWORD_PERMANENT = "password_permanent";
@@ -72,6 +75,7 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
         attrs.add(Name.NAME);
         attrs.add(ATTR_CREATED_TIMESTAMP);
         attrs.add(ATTR_GROUPS);
+        attrs.add(ATTR_ROLES);
         attrs.add(ATTR_PASSWORD_PERMANENT);
         attrs.addAll(OperationalAttributes.OPERATIONAL_ATTRIBUTE_NAMES);
 
@@ -183,6 +187,10 @@ public class KeycloakUserHandler extends AbstractKeycloakHandler {
 
         // Association
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_GROUPS)
+                .setMultiValued(true)
+                .setReturnedByDefault(false)
+                .build());
+        builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_ROLES)
                 .setMultiValued(true)
                 .setReturnedByDefault(false)
                 .build());

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTAdminClient.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTAdminClient.java
@@ -49,6 +49,7 @@ public class KeycloakAdminRESTAdminClient implements KeycloakClient {
     private final KeycloakAdminRESTGroup group;
     private final KeycloakAdminRESTClient client;
     private final KeycloakAdminRESTClientRole clientRole;
+    private final KeycloakAdminRESTRealmRole realmRole;
     private Keycloak adminClient;
 
     public KeycloakAdminRESTAdminClient(String instanceName, KeycloakConfiguration configuration) {
@@ -113,6 +114,7 @@ public class KeycloakAdminRESTAdminClient implements KeycloakClient {
         this.group = new KeycloakAdminRESTGroup(instanceName, configuration, adminClient);
         this.client = new KeycloakAdminRESTClient(instanceName, configuration, adminClient);
         this.clientRole = new KeycloakAdminRESTClientRole(instanceName, configuration, adminClient);
+        this.realmRole = new KeycloakAdminRESTRealmRole(instanceName, configuration, adminClient);
     }
 
     private RealmResource realm(String realmName) {
@@ -161,6 +163,11 @@ public class KeycloakAdminRESTAdminClient implements KeycloakClient {
     @Override
     public ClientRole clientRole() {
         return clientRole;
+    }
+
+    @Override
+    public RealmRole realmRole() {
+        return realmRole;
     }
 
     @Override

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTRealmRole.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTRealmRole.java
@@ -1,0 +1,301 @@
+/*
+ *  Copyright Nomura Research Institute, Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package jp.openstandia.connector.keycloak.rest;
+
+import jp.openstandia.connector.keycloak.KeycloakClient;
+import jp.openstandia.connector.keycloak.KeycloakConfiguration;
+import jp.openstandia.connector.keycloak.KeycloakSchema;
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
+import org.identityconnectors.framework.common.exceptions.UnknownUidException;
+import org.identityconnectors.framework.common.objects.*;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.*;
+
+import static jp.openstandia.connector.keycloak.KeycloakRealmRoleHandler.*;
+import static jp.openstandia.connector.keycloak.KeycloakUtils.*;
+
+/**
+ * Keycloak realmRole implementation for realmRole object which uses Keycloak Admin REST client.
+ *
+ * @author Hiroyuki Wada
+ */
+public class KeycloakAdminRESTRealmRole implements KeycloakClient.RealmRole {
+
+    private static final Log LOGGER = Log.getLog(KeycloakAdminRESTRealmRole.class);
+
+    private final String instanceName;
+    private final KeycloakConfiguration configuration;
+    private Keycloak adminClient;
+
+    public KeycloakAdminRESTRealmRole(String instanceName, KeycloakConfiguration configuration, Keycloak adminClient) {
+        this.instanceName = instanceName;
+        this.configuration = configuration;
+        this.adminClient = adminClient;
+    }
+
+    private RealmResource realm(String realmName) {
+        return adminClient.realm(realmName);
+    }
+
+    private RoleRepresentation realmRole(String realmName, Uid uid) {
+        return realm(realmName).rolesById().getRole(uid.getUidValue());
+    }
+
+    private RoleRepresentation realmRole(String realmName, Name name) {
+        return realm(realmName).roles().get(name.getNameValue()).toRepresentation();
+    }
+
+    @Override
+    public Uid createRealmRole(KeycloakSchema schema, String realmName, Set<Attribute> createAttributes) throws AlreadyExistsException {
+        RoleRepresentation rep = toRealmRoleRep(schema, createAttributes);
+
+        if (rep.getName() == null) {
+            throw new InvalidAttributeValueException("Must define name for the realmRole object");
+        }
+
+        RolesResource rolesResource = realm(realmName).roles();
+
+        rolesResource.create(rep);
+
+        RoleRepresentation created = rolesResource.get(rep.getName()).toRepresentation();
+
+        // If the API doesn't support putting attributes when creating, we need to update the realmRole here
+        if (rep.getAttributes() != null && !rep.getAttributes().isEmpty() && created.getAttributes().isEmpty()) {
+            created.setAttributes(rep.getAttributes());
+            realm(realmName).rolesById().updateRole(created.getId(), created);
+        }
+
+        return new Uid(created.getId(), new Name(created.getName()));
+    }
+
+    protected RoleRepresentation toRealmRoleRep(KeycloakSchema schema, Set<Attribute> attributes) {
+        RoleRepresentation newRealmRole = new RoleRepresentation();
+        newRealmRole.setClientRole(false);
+
+        for (Attribute attr : attributes) {
+            if (attr.getName().equals(Name.NAME)) {
+                newRealmRole.setName(AttributeUtil.getAsStringValue(attr));
+
+            } else if (attr.getName().equals(ATTR_DESCRIPTION)) {
+                newRealmRole.setDescription(AttributeUtil.getStringValue(attr));
+
+            } else if (attr.getName().equals(ATTR_ATTRIBUTES)) {
+                // Configured Attributes
+                Map<String, List<String>> attrs = newRealmRole.getAttributes();
+                if (attrs == null) {
+                    attrs = new HashMap();
+                }
+
+                List<Object> values = attr.getValue();
+                for (Object v : values) {
+                    String kv = v.toString();
+                    int index = kv.indexOf("=");
+                    if (index <= 0) {
+                        throw new InvalidAttributeValueException("The attribute is invalid format: " + kv);
+                    }
+                    String key = kv.substring(0, index);
+                    String value = kv.substring(index + 1);
+
+                    attrs.put(key, Arrays.asList(value.split("##")));
+                }
+
+                newRealmRole.setAttributes(attrs);
+            }
+        }
+
+        return newRealmRole;
+    }
+
+    @Override
+    public void updateRealmRole(KeycloakSchema schema, String realmName, Uid uid, Set<AttributeDelta> modifications, OperationOptions options) throws UnknownUidException {
+        RoleRepresentation current = realmRole(realmName, uid);
+
+        try {
+            for (AttributeDelta delta : modifications) {
+                if (delta.getName().equals(Name.NAME)) {
+                    current.setName(AttributeDeltaUtil.getAsStringValue(delta));
+
+                } else if (delta.getName().equals(ATTR_DESCRIPTION)) {
+                    current.setDescription(AttributeDeltaUtil.getStringValue(delta));
+
+                } else if (delta.getName().equals(ATTR_ATTRIBUTES)) {
+                    // Configured Attributes
+                    Map<String, List<String>> attrs = current.getAttributes();
+                    if (attrs == null) {
+                        attrs = new HashMap();
+                    }
+
+                    // First, we need to remove the attributes
+                    if (delta.getValuesToRemove() != null) {
+                        for (Object v : delta.getValuesToRemove()) {
+                            String kv = v.toString();
+                            int index = kv.indexOf("=");
+                            if (index <= 0) {
+                                throw new InvalidAttributeValueException("The attribute is invalid format: " + kv);
+                            }
+                            String key = kv.substring(0, index);
+
+                            if (schema.realmRoleSchema != null && schema.realmRoleSchema.containsKey(key)) {
+                                LOGGER.ok("Ignore removing attributes because it's configured attribute");
+                                continue;
+                            }
+
+                            attrs.remove(key);
+                        }
+                    }
+                    if (delta.getValuesToAdd() != null) {
+                        for (Object v : delta.getValuesToAdd()) {
+                            String kv = v.toString();
+                            int index = kv.indexOf("=");
+                            if (index <= 0) {
+                                throw new InvalidAttributeValueException("The attribute is invalid format: " + kv);
+                            }
+                            String key = kv.substring(0, index);
+                            String value = kv.substring(index + 1);
+
+                            if (schema.realmRoleSchema != null && schema.realmRoleSchema.containsKey(key)) {
+                                LOGGER.ok("Ignore putting attributes because it's configured attribute");
+                                continue;
+                            }
+
+                            attrs.put(key, Arrays.asList(value.split("##")));
+                        }
+                    }
+
+                    current.setAttributes(attrs);
+
+                } else {
+                    invalidSchema(delta.getName());
+                }
+            }
+
+            // TODO Optimize update if no diff
+            realm(realmName).rolesById().updateRole(current.getId(), current);
+
+        } catch (NotFoundException e) {
+            LOGGER.warn("Not found realmRole when updating. uid: {0}", uid);
+            throw new UnknownUidException(uid, REALM_ROLE_OBJECT_CLASS);
+        }
+
+    }
+
+    @Override
+    public void deleteRealmRole(KeycloakSchema schema, String realmName, Uid uid, OperationOptions options) throws UnknownUidException {
+        try {
+            realm(realmName).rolesById().deleteRole(uid.getUidValue());
+
+        } catch (NotFoundException e) {
+            LOGGER.warn("[{0}] Not found realmRole when deleting. uid: {1}", instanceName, uid);
+            throw new UnknownUidException(uid, REALM_ROLE_OBJECT_CLASS);
+        }
+    }
+
+    @Override
+    public void getRealmRoles(KeycloakSchema schema, String realmName, ResultsHandler handler, OperationOptions options,
+                               Set<String> attributesToGet, int queryPageSize) {
+        boolean allowPartialAttributeValues = shouldAllowPartialAttributeValues(options);
+
+        RealmResource realmResource = realm(realmName);
+        RolesResource rolesResource = realmResource.roles();
+
+        // TODO paging
+        List<RoleRepresentation> realmRoles = rolesResource.list();
+
+        realmRoles.stream().forEach(cr -> {
+            handler.handle(toConnectorObject(schema, realmName, cr, attributesToGet, allowPartialAttributeValues, queryPageSize));
+        });
+    }
+
+    @Override
+    public void getRealmRole(KeycloakSchema schema, String realmName, Uid uid, ResultsHandler handler, OperationOptions options,
+                              Set<String> attributesToGet, int queryPageSize) {
+        try {
+            RoleRepresentation rep = realmRole(realmName, uid);
+
+            if (rep == null) {
+                LOGGER.warn("[{0}] Unknown realmRole uuid: {1}, name: {2}", instanceName, uid.getUidValue(), uid.getNameHintValue());
+                return;
+            }
+
+            boolean allowPartialAttributeValues = shouldAllowPartialAttributeValues(options);
+
+            handler.handle(toConnectorObject(schema, realmName, rep, attributesToGet, allowPartialAttributeValues, queryPageSize));
+
+        } catch (NotFoundException e) {
+            LOGGER.warn("[{0}] Unknown realmRole uuid: {1}, name: {2}", instanceName, uid.getUidValue(), uid.getNameHintValue());
+            return;
+        }
+    }
+
+    @Override
+    public void getRealmRole(KeycloakSchema schema, String realmName, Name name, ResultsHandler handler, OperationOptions options,
+                              Set<String> attributesToGet, int queryPageSize) {
+        try {
+            RoleRepresentation rep = realmRole(realmName, name);
+
+            if (rep == null) {
+                LOGGER.warn("[{0}] Unknown realmRole name: {1}", instanceName, name.getNameValue());
+                return;
+            }
+
+            boolean allowPartialAttributeValues = shouldAllowPartialAttributeValues(options);
+
+            handler.handle(toConnectorObject(schema, realmName, rep, attributesToGet, allowPartialAttributeValues, queryPageSize));
+
+        } catch (NotFoundException e) {
+            LOGGER.warn("[{0}] Unknown realmRole name: {1}", instanceName, name.getNameValue());
+            return;
+        }
+    }
+
+    private ConnectorObject toConnectorObject(KeycloakSchema schema, String realmName, RoleRepresentation rep,
+                                              Set<String> attributesToGet, boolean allowPartialAttributeValues, int queryPageSize) {
+        final ConnectorObjectBuilder builder = new ConnectorObjectBuilder()
+                .setObjectClass(REALM_ROLE_OBJECT_CLASS)
+                // Always returns "id"
+                .setUid(rep.getId())
+                // Always returns "name"
+                .setName(rep.getName());
+
+        if (shouldReturn(attributesToGet, ATTR_DESCRIPTION)) {
+            builder.addAttribute(ATTR_DESCRIPTION, rep.getDescription());
+        }
+
+        if (shouldReturn(attributesToGet, ATTR_ATTRIBUTES)) {
+            Map<String, List<String>> attributes = rep.getAttributes();
+            List<String> genericAttributes = new ArrayList<>();
+            if (attributes != null) {
+                for (Map.Entry<String, List<String>> entry : rep.getAttributes().entrySet()) {
+                    String a = entry.getKey();
+
+                    // Collect attributes as key=value formatted text
+                    genericAttributes.add(String.format("%s=%s", a, String.join("##", entry.getValue())));
+                }
+            }
+
+            builder.addAttribute(ATTR_ATTRIBUTES, genericAttributes);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
+++ b/src/main/java/jp/openstandia/connector/keycloak/rest/KeycloakAdminRESTUser.java
@@ -31,6 +31,7 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import jakarta.ws.rs.BadRequestException;
@@ -91,6 +92,13 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         // Remove groups intentionally because keycloak expects group path list
         newUser.setGroups(null);
 
+        List<String> addRoles = new ArrayList<>();
+        for (Attribute attr : createAttributes) {
+            if (attr.getName().equals(ATTR_ROLES)) {
+                addRoles = attr.getValue().stream().map(a -> a.toString()).collect(Collectors.toList());
+            }
+        }
+
         Response res = users(realmName).create(newUser);
 
         String uuid = checkCreateResult(res, "createUser");
@@ -114,6 +122,22 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                     LOGGER.warn("The group is not found already. Skipping join the user. groupId: {0}, userId: {1}, username: {2}",
                             groupId, uuid, newUser.getUsername());
                 }
+            }
+        }
+
+        if (!addRoles.isEmpty()) {
+            List<RoleRepresentation> rolesToAdd = new ArrayList<>();
+            for (String roleName : addRoles) {
+                try {
+                    RoleRepresentation role = realm(realmName).roles().get(roleName).toRepresentation();
+                    rolesToAdd.add(role);
+                } catch (NotFoundException e) {
+                    LOGGER.warn("The role is not found. Skipping join the user. roleName: {0}, userId: {1}, username: {2}",
+                            roleName, uuid, newUser.getUsername());
+                }
+            }
+            if (!rolesToAdd.isEmpty()) {
+                users(realmName).get(uuid).roles().realmLevel().add(rolesToAdd);
             }
         }
 
@@ -163,6 +187,11 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                 List<String> groups = attr.getValue().stream().map(a -> a.toString()).collect(Collectors.toList());
                 newUser.setGroups(groups);
 
+            } else if (attr.getName().equals(ATTR_ROLES)) {
+                // Keycloak expects roles to be mapped via RoleMappingResource.
+                // We handle it in createUser method.
+                // Do nothing here explicitly to avoid falling into the default branch.
+
             } else {
                 if (!schema.isUserSchema(attr)) {
                     throw new InvalidAttributeValueException(String.format("Keycloak doesn't support to set '%s' attribute of User",
@@ -207,6 +236,8 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
         UserRepresentation current;
         List<String> addGroupIds = new ArrayList<>();
         List<String> removeGroupIds = new ArrayList<>();
+        List<String> addRoles = new ArrayList<>();
+        List<String> removeRoles = new ArrayList<>();
         CredentialRepresentation credential = null;
 
         try {
@@ -259,6 +290,18 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
                     if (delta.getValuesToRemove() != null) {
                         for (Object group : delta.getValuesToRemove()) {
                             removeGroupIds.add(group.toString());
+                        }
+                    }
+
+                } else if (delta.getName().equals(ATTR_ROLES)) {
+                    if (delta.getValuesToAdd() != null) {
+                        for (Object role : delta.getValuesToAdd()) {
+                            addRoles.add(role.toString());
+                        }
+                    }
+                    if (delta.getValuesToRemove() != null) {
+                        for (Object role : delta.getValuesToRemove()) {
+                            removeRoles.add(role.toString());
                         }
                     }
 
@@ -335,6 +378,38 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
             } catch (NotFoundException e) {
                 LOGGER.warn("The group is not found already. Skipping join the user. groupId: {0}, userId: {1}, username: {2}",
                         groupId, current.getId(), current.getUsername());
+            }
+        }
+
+        if (!addRoles.isEmpty()) {
+            List<RoleRepresentation> rolesToAdd = new ArrayList<>();
+            for (String roleName : addRoles) {
+                try {
+                    RoleRepresentation role = realm(realmName).roles().get(roleName).toRepresentation();
+                    rolesToAdd.add(role);
+                } catch (NotFoundException e) {
+                    LOGGER.warn("The role is not found. Skipping join the user. roleName: {0}, userId: {1}, username: {2}",
+                            roleName, current.getId(), current.getUsername());
+                }
+            }
+            if (!rolesToAdd.isEmpty()) {
+                users(realmName).get(current.getId()).roles().realmLevel().add(rolesToAdd);
+            }
+        }
+
+        if (!removeRoles.isEmpty()) {
+            List<RoleRepresentation> rolesToRemove = new ArrayList<>();
+            for (String roleName : removeRoles) {
+                try {
+                    RoleRepresentation role = realm(realmName).roles().get(roleName).toRepresentation();
+                    rolesToRemove.add(role);
+                } catch (NotFoundException e) {
+                    LOGGER.warn("The role is not found. Skipping remove the user. roleName: {0}, userId: {1}, username: {2}",
+                            roleName, current.getId(), current.getUsername());
+                }
+            }
+            if (!rolesToRemove.isEmpty()) {
+                users(realmName).get(current.getId()).roles().realmLevel().remove(rolesToRemove);
             }
         }
     }
@@ -491,17 +566,32 @@ public class KeycloakAdminRESTUser implements KeycloakClient.User {
             ab.setName(ATTR_GROUPS).setAttributeValueCompleteness(AttributeValueCompleteness.INCOMPLETE);
             ab.addValue(Collections.EMPTY_LIST);
             builder.addAttribute(ab.build());
+
+            AttributeBuilder arb = new AttributeBuilder();
+            arb.setName(ATTR_ROLES).setAttributeValueCompleteness(AttributeValueCompleteness.INCOMPLETE);
+            arb.addValue(Collections.EMPTY_LIST);
+            builder.addAttribute(arb.build());
         } else {
             if (attributesToGet == null) {
-                // Suppress fetching groups default
-                LOGGER.ok("[{0}] Suppress fetching groups because returned by default is true", instanceName);
+                // Suppress fetching groups/roles default
+                LOGGER.ok("[{0}] Suppress fetching groups/roles because returned by default is false", instanceName);
 
-            } else if (shouldReturn(attributesToGet, ATTR_GROUPS)) {
-                // Fetch groups
-                LOGGER.ok("[{0}] Fetching groups because attributes to get is requested", instanceName);
+            } else {
+                if (shouldReturn(attributesToGet, ATTR_GROUPS)) {
+                    // Fetch groups
+                    LOGGER.ok("[{0}] Fetching groups because attributes to get is requested", instanceName);
 
-                List<GroupRepresentation> groups = users(realmName).get(user.getId()).groups();
-                builder.addAttribute(ATTR_GROUPS, groups.stream().map(g -> g.getId()).collect(Collectors.toList()));
+                    List<GroupRepresentation> groups = users(realmName).get(user.getId()).groups();
+                    builder.addAttribute(ATTR_GROUPS, groups.stream().map(g -> g.getId()).collect(Collectors.toList()));
+                }
+
+                if (shouldReturn(attributesToGet, ATTR_ROLES)) {
+                    // Fetch roles
+                    LOGGER.ok("[{0}] Fetching roles because attributes to get is requested", instanceName);
+
+                    List<RoleRepresentation> roles = users(realmName).get(user.getId()).roles().realmLevel().listAll();
+                    builder.addAttribute(ATTR_ROLES, roles.stream().map(r -> r.getName()).collect(Collectors.toList()));
+                }
             }
         }
 


### PR DESCRIPTION
I created a patch to support Realm Roles using Google Antigravity.
example account attribute,
```
            <attribute>
                <ref>ri:roles</ref>
                <tolerant>false</tolerant>
                <fetchStrategy>explicit</fetchStrategy>
                <outbound>
                    <strength>strong</strength>
                    <source>
                        <path>assignment</path>
                    </source>
                    <expression>
                        <script>
                            <code>
                                import com.evolveum.midpoint.xml.ns._public.common.common_3.RoleType

                                log.debug("Evaluating assignment for Keycloak ri:roles mapping...")

                                if (assignment != null &amp;&amp; assignment.getTargetRef() != null) {
                                    def targetType = assignment.getTargetRef().getType().getLocalPart()
                                    def targetOid = assignment.getTargetRef().getOid()
                                    
                                    log.debug("Assignment target type: '{}', OID: '{}'", targetType, targetOid)

                                    if (targetType == "RoleType") {
                                        try {
                                            def role = midpoint.getObject(RoleType.class, targetOid)
                                            if (role != null) {
                                                def roleName = role.getName().getOrig()
                                                log.info("Successfully resolved RoleType (OID: {}). Assigning Keycloak role: '{}'", targetOid, roleName)
                                                return roleName
                                            } else {
                                                log.warn("RoleType with OID {} was referenced in assignment but not found in midPoint.", targetOid)
                                            }
                                        } catch (Exception e) {
                                            log.error("Error resolving RoleType with OID {}: {}", targetOid, e.getMessage())
                                            return null
                                        }
                                    } else {
                                        log.debug("Target type is '{}', skipping (only looking for RoleType).", targetType)
                                    }
                                } else {
                                    log.debug("Assignment or targetRef is null. Skipping.")
                                }
                                
                                return null
                            </code>
                        </script>
                    </expression>
                </outbound>
            </attribute>
```
example objectType
```
        <objectType>
            <kind>entitlement</kind>
            <intent>realm-role</intent>
            <displayName>Keycloak Realm Role</displayName>
            <delineation>
                <objectClass>ri:realmRole</objectClass>
            </delineation>
            <focus>
                <type>c:RoleType</type>
            </focus>
            <attribute>
                <ref>ri:name</ref>
                <outbound>
                    <name>Name</name>
                    <strength>strong</strength>
                    <source>
                        <path>name</path>
                    </source>
                </outbound>
            </attribute>
            <attribute>
                <ref>ri:realmRoleId</ref>
                <inbound id="56">
                    <name>RealmRoleId</name>
                    <strength>strong</strength>
                    <target>
                        <path>identifier</path>
                    </target>
                </inbound>
            </attribute>
        </objectType>
```

